### PR TITLE
Delete secrets from publicly accessible files

### DIFF
--- a/twitter_stream_parser.py
+++ b/twitter_stream_parser.py
@@ -22,10 +22,10 @@ stateAbbreviationMap = {'Alaska':'AK','Alabama':'AL','Arkansas':'AR','Arizona':'
 #our consumer key and secret for our application to receive tweets from the public stream
 #these will not actually be used for anything except to listen for tweets
 consumer_key="ldtUZH7082RW6nZKkTILmC3p7"
-consumer_secret="vd0hjyt7BX9fFZQ1ShmNkaS6lk55kTs0RbapV7reEjbGSmnrUf"
+consumer_secret=""
 
 access_token="870183469-83KQSCFJF16C6i3dEhRWBW63WKXhahU5SLoOQ7TM"
-access_token_secret="Z60oe2vJvUTk30EUApwewW61fB4eV5PGQ05Nllys2GcQT"
+access_token_secret=""
 
 #connect on the default host, which is where we are running MongoDB listener
 client = MongoClient()


### PR DESCRIPTION
From the twitter developer guidelines:
Keep the "Consumer Secret" a secret. This key should never be human-readable in your application.
This access token can be used to make API requests on your own account's behalf. Do not share your access token secret with anyone. 

Since the secrets were  publicly accecisble from the internet and they are now part of the git history  you should generate a new pair! 

Greetings from Berlin